### PR TITLE
Update make.bat

### DIFF
--- a/core/src/overture/make.bat
+++ b/core/src/overture/make.bat
@@ -60,8 +60,6 @@ IF "%ERRORLEVEL%" == 1 (
     EXIT 1
 )
 
-
-REM SET GOROOT=%DIR%\go
 SET GOPATH=%DIR%
 SET PATH=%GOPATH%\bin;%PATH%
 


### PR DESCRIPTION
We can't require that all users have installed go.exe under the %DIR%\go directory which will lead to an error when building with Android Studio.
So I fix the lines from 63 to 73(delete the go env checking and building since README.md has told users this project needs go and correct the PATH setting)to make this bat work fine.